### PR TITLE
feat: Start hugo and show outdated packages

### DIFF
--- a/emacs.yml
+++ b/emacs.yml
@@ -8,3 +8,4 @@ windows:
       layout: tiled
       panes:
         - git st
+        - cat /tmp/emacs-outdated-packages.txt

--- a/emacs.yml
+++ b/emacs.yml
@@ -8,4 +8,5 @@ windows:
       layout: tiled
       panes:
         - git st
+        - cd hugo && hugo server -D
         - cat /tmp/emacs-outdated-packages.txt


### PR DESCRIPTION
emacs.yml の起動時に
cache している「古くなったパッケージリスト」を表示し
hugo も起動するようにした

cache の仕組みは
https://github.com/mugijiru/.emacs.d/pull/958
https://github.com/mugijiru/dotfiles/pull/32
の組み合わせで、
Emacs Lisp で書いた更新チェック用のスクリプトを i3block で定期実行している。

スクリプト側で /tmp/emacs-outdated-packages.txt を出力しているので
それを cat で表示しているだけ。

Hugo は、init.org を弄る時にチェックするために使っている